### PR TITLE
Moving changes for rockstor-core issue 2206 to its own repo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+#lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Pycharm
+.idea/
+
+# Node Modules
+node_modules/
+
+# VS Code
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,0 +1,277 @@
+Introduction
+------------
+You can use this vagrant environment to build a vagrant box VM of a confirmed working 
+specification with rockstor installed from source for testing.
+
+It will use the ansible playbook and roles in this repository to perform the VM provisioning. However,
+Vagrant generates it's own host inventory since it operates using the vagrant user. eg.
+
+```yaml
+ANSIBLE_GROUPS = {
+  "all_groups" => ["rockstor"],
+  "all_groups:vars" => {
+        "rs_inst_set_root_pass" => "true"
+        }
+}
+```
+
+Pre-requesits
+-------------
+It is assumped that you have the follow software packages install on you host machine:
+- Vagrant (https://www.vagrantup.com/downloads)
+- Ansible - see this [README](ansible/README.md) for download instructions.
+
+All above packages are available on Linux, Mac OSX and Windows.
+
+You will also need one of the following virtualisation platforms:
+  - <b>Linux users:</b> may prefer to use libvirt, qemu + kxm (see https://github.com/vagrant-libvirt/vagrant-libvirt)
+
+    or 
+  - Virtualbox is available on all platforms (https://www.virtualbox.org/wiki/Downloads)
+ 
+
+It is also assumed that you have a local copy of the core repository [rockstor-core](https://github.com/rockstor/rockstor-core) 
+on your machine at the same level as this repo:
+
+```
+.../rockstor-core
+.../rockstor-dev-env
+
+```
+
+You should also be currently within the 'vagrant_env' directory in this repo, where the 'Vagrantfile' is located.
+
+Vagrant Boxes
+-------------
+
+This Vagrantfile uses a number of vagrant box: 
+
+- [opensuse/leap-15.2.x86_64](https://app.vagrantup.com/opensuse/boxes/Leap-15.2.x86_64)
+- [opensuse/Tumbleweed.x86_64](https://app.vagrantup.com/opensuse/boxes/Tumbleweed.x86_64)
+- [opensuse/Tumbleweed.aarch64](https://app.vagrantup.com/opensuse/boxes/Tumbleweed.aarch64)
+
+Building an OpenSUSE Leap VM and installing Rockstor from source
+----------------------------------------------------------------
+On Mac OSX, Linux and Windows:
+
+```shell script
+./build.sh
+```
+
+This will, by default, build and provision an OpenSUSE Leap 15.2 vagrant box in libvirt - including rsyncing the source to the 
+VM in /root. It will then build and install Rockstor from source as per the install guide in the top level README.md.
+
+Should you prefer to user virtual box you can perform the following:
+
+```shell script
+./build.sh leap virtualbox
+```
+
+The VM window should have popped up and show the usual Rockstor messages regarding how to reach the Web UI. eg.
+
+```
+Rockstor is successfully installed.
+
+web-ui is accessible with the follow links:
+https://127.0.0.1
+https://10.0.2.15
+https://172.28.128.101
+https://172.28.128.100
+rockstor login:
+```  
+
+Note: your IPs may well vary.
+
+CAUTION: This command will ALWAYS do a clean build due to the nature of the vagrant rsync which uses the rsync 
+option --delete.
+
+To do subsequent builds see the Aliases section that follows on how to login as root and run further operations.
+
+Accessing Rockstor on the VMs
+-----------------------------
+Port forwarding is used to provide local access to the Rockstor Web UI. To allow you to have Rockstor built and 
+running in each platform side by side port the ports are assigned as follows:
+
+|VM Name|Host Port|Guest Port|Example URL|
+|-------|---------|----------|-----------|
+|rockstor-leap|2443|443|https://172.28.128.101:2443|
+|rockstor-tw|2444|443|https://172.28.128.101:2444|
+|rockstor-pi|2445|443|https://172.28.128.101:2445|
+
+
+Aliases
+-------
+
+Some aliases are define in the file 'alias_rc' to assist with some commands detailed in: 
+http://rockstor.com/docs/contribute.html#developers
+
+These are appended onto the file /root/.bashrc so that they are available 
+when logged in as the root user. 
+
+Typically in the world of vagrant you login as the user 'vagrant' and sudo operating. However, for ease in this case
+and in line with the instruction you can also log in as root in one of the following ways:
+
+```
+host> vagrant ssh
+:
+vm> su root
+password: vagrant
+vm> cd
+```
+
+or
+
+```
+host> ssh root@<vm IP>
+password: vagrant
+```
+If you have set the ansible option `rs_inst_set_root_pass: yes` then the root password will be defined in 
+[ansible/defaults/main.yml](../ansible/defaults/main.yml) and defaults to 'password'
+
+From here the aliases can used. Here is a summary of them:
+
+```
+build_init
+build_all
+build_ui
+make_mig_stadm
+apply_migrations_stadm
+make_mig_smtmgr
+apply_migrations_smtmgr
+```
+See [alias_rc](vagrant_env/alias_rc) for details
+
+Deploy from Testing Channel
+---------------------------
+
+If you wish to deploy a VM from the Test Channel RPMs (rather than building from source) you need to update 
+the ansible playbook 'ansible/Rockstor.yml' to set the variable 'rs_inst_install_from_repo:yes' as follows:
+
+```
+  roles:
+    - role: rockstor_installer
+      vars:
+        rs_inst_install_from_repo: yes
+```
+
+Then simply bring up the VM using the command:
+```
+vagrant up
+```
+
+Do NOT run 'build.sh' in this scenario.
+
+Building for Tumbleweed and Aarch64
+-----------------------------------
+
+To build for Tumbleweed x86_64 in libvirt:
+```shell script
+./build.sh tw
+```
+or for virtual box:
+```shell script
+./build.sh tw virtualbox
+```
+
+To build for Tumbleweed Aarch64 in libvirt:
+
+[Work in progress... and only on libvirt] [see vagrant libvirt plugin](https://github.com/vagrant-libvirt/vagrant-libvirt)]
+
+<s>
+
+```shell script
+./build.sh pi
+```
+or for virtual box:
+```shell script
+./build.sh pi virtualbox
+```
+
+</s>
+
+Managing the Virtual Machine
+----------------------------
+To manage the Vagrant box VM simple type the following from this directory...
+
+- Enable disk management to allow creation of data disks requires the enablement 
+of the experimental 'disk' feature:
+    ```
+    export VAGRANT_EXPERIMENTAL="disks"  # <-- may be in ~/.profile, /etc/profile, or elsewhere
+    export VAGRANT_DEFAULT_PROVIDER=kvm  # <-- may be in ~/.profile, /etc/profile, or elsewhere
+    ```
+  Note: This is enabled in 'build.sh' but needs external enablement if you wish to use descrete vagrant calls below.
+
+- Bring up all vagrant box VMs in libvirt
+    ```shell script
+    vagrant up --provider=libvirt
+    ```
+  or for virtual box
+    ```shell script
+    vagrant up --provider=virtualbox
+    ```
+    Note: You can NOT manage boxes in both libvirt and virtual box at the same time.
+     
+- Bring up a particular vagrant box VM
+    ```shell script
+    vagrant up <box-name eg. rockstor-core> --provider=libvirt
+    ```
+
+- Reconfigure the vagrant box VM following a change to the Vagrantfile:
+    ```shell script
+    vagrant reload
+    ```
+    or
+    ```shell script
+    vagrant reload <box-name eg. rockstor-core>
+    ```
+
+- If you change the provisioner section of the Vagrantfile or update the ansible, you can rerun just that part as follows:
+    ```shell script
+    vagrant provision
+    ```
+    or
+    ```shell script
+    vagrant provision <box-name eg. rockstor-core>
+    ```
+
+- Destroy the vagrant box VM:
+    ```shell script
+    vagrant destroy
+    ```
+    or
+    ```shell script
+    vagrant destroy <box-name eg. rockstor-core>
+    ```
+
+- If you wish to ssh into the vagrant box VM to poke around, try this:
+    ```shell script
+    vagrant ssh
+    ```
+    or
+    ```shell script
+    vagrant ssh <box-name eg. rockstor-core>
+    ```
+
+- If you wish to re-rsync your source files (warning this will have the effect of cleaning the build too due 
+to using the --delete options):
+    ```
+    vagrant rsync
+    ```
+    or
+    ```shell script
+    vagrant rsync <box-name eg. rockstor-core>
+    ```
+  
+Debuging the Ansible
+--------------------
+
+If you need additional debug for the ansible add additional 'v' to the provisioners 
+verbosity variable in the Vagrantfile. eg.
+```
+        config.vm.provision "rockstor", type: "ansible" do |ansible|
+            ansible.config_file = "../ansible/ansible.cfg"
+            ansible.playbook = "../ansible/Rockstor.yml"
+            ansible.verbose = "vvvv"
+            ansible.groups = ANSIBLE_GROUPS
+        end
+```

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,89 @@
+Introduction
+------------
+You can use this ansible environment to provision a VM or physical hose with a confirmed working 
+specification with rockstor.
+
+Pre-requesits
+-------------
+It is assumped that you have the follow software packages install on you host machine:
+
+- ansible
+
+There are a number of ways to install this depending on your Host OS.
+ 
+####Mac OSX
+
+1. Install [brew](https://brew.sh)
+    ```
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+    ```
+2. [option 1] Install ansible from brew:
+    ```
+    brew install ansible
+    ```
+    or
+   
+   [option 2] If you feel like running ansible from 'pip' under python 3:
+    ```
+    brew install pyenv
+    pyenv install 3.8.5
+    pyenv local 3.8.5
+    pip install ansible
+    ```
+    Note: you may find you need to install the OSX Xcode commandline build tools for pyenv to build your python version.
+    
+####Linux
+
+Working under linux will be slightly distribution dependent but similar to Mac OSX options.
+
+OpenSUSE:
+1. Install from your package manager:
+    ```
+    zypper install ansible
+    ```
+2. Install through 'pip':
+    ```
+    pip install ansible
+    ```
+
+####Windows
+
+Follow this [guide](https://www.jeffgeerling.com/blog/2017/using-ansible-through-windows-10s-subsystem-linux) by Jeff Geerling.
+
+
+It is also assumed that you have a local copy of this repository [rockstor-core](https://github.com/rockstor/rockstor-core) 
+on your machine, see the top level README.md, and are currently within the 'vagrant_env' directory: where the 
+Vagrantfile is located.
+
+The Inventory
+-------------
+The file inventory/hosts.yml contains details of the host you are provisioning with ansible. You will need to add your
+hosts IP to this line:
+```
+rockstor ansible_ssh_host=<your_host_ip>
+```
+If your host has a different user from 'root' for provisioning you can also set that in the hosts.yml on this line:
+```
+[all:vars]
+ansible_ssh_user=root
+```
+Running the Ansible
+-------------------
+To run the provisioner:
+```
+ansible-playbook Rockstor.yml --ask-pass
+```
+This will prompt you for the password of the user defined in the 'ansible_ssh_user' in the inventory/hosts.yml.
+
+If you would like a little debug for the ansible execution (and this is my normal level of debug) try:
+```
+ansible-playbook Rockstor.yml --ask-pass -vv
+```
+
+If you happen to already have an authorised ssh key added to the 'ansible_ssh_user' on the rockstor host
+then you can just type the following:
+```
+ansible-playbook Rockstor.yml
+```
+
+

--- a/ansible/Rockstor.yml
+++ b/ansible/Rockstor.yml
@@ -1,0 +1,18 @@
+---
+- hosts: all
+  become: yes
+  become_user: root
+
+  roles:
+    - role: rockstor_installer
+      vars:
+        rs_inst_update_os: yes
+#        rs_inst_install_from_repo: yes
+#        rs_inst_set_root_pass: yes
+#        rs_inst_experimental: yes
+#        rs_inst_useful_server_packages:
+#            - ffmpeg
+#            - mediainfo
+#            - mosh
+#            - tmux
+#            - tree

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,10 @@
+[defaults]
+inventory = inventory
+roles_path=./installed_roles:./roles
+nocows = 1
+host_key_checking = False
+transport = paramiko
+#interpreter_python = python # Forces the ansible python interpret to follow pyenv
+
+[ssh_connection]
+ssh_args=-o ForwardAgent=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null

--- a/ansible/inventory/hosts
+++ b/ansible/inventory/hosts
@@ -1,0 +1,5 @@
+rockstor ansible_ssh_host=<your_host_ip>
+
+[all:vars]
+ansible_ssh_user=root
+

--- a/ansible/roles/rockstor_installer/README.md
+++ b/ansible/roles/rockstor_installer/README.md
@@ -1,0 +1,77 @@
+This role has is a refactoring of the good work by Stephen Brown in his repo 
+here: https://gitlab.com/StephenBrown2/rockstor-opensuse
+
+Kudos to him for this excellent work.
+
+## Main variables
+
+There are some variables in default/main.yml which can (or need to) be overridden:
+
+* `rs_inst_install_from_repo`: no[default] or yes. Install direct from testing repo.
+* `rs_inst_experimental`: no[default] or yes. Controls whether the latest BTRFS is included.
+* `rs_inst_set_root_pass`: no[default] or yes. Sometimes needed on first time installs of OpenSUSE.
+* `rs_inst_root_password`: The root password to be set. Must be encrypted eg. 
+    ```yaml
+    rs_inst_root_password: "{{ 'root' | password_hash('sha512', 'mysecretsalt') }}"
+    ```
+* `rs_inst_update_os`: no[default] or yes. Choose to update the OS packages or not.
+* `rs_inst_useful_server_packages`: A list of useful addition packages to install on the server (eg. to support a Rock-On).
+
+## Vars in role configuration
+Including an example of how to use your role (for instance, with variables passed in as parameters):
+```yaml
+---
+- hosts: all
+  become: yes
+  become_user: root
+
+  roles:
+    - role: rockstor_installer
+      vars:
+        rs_inst_install_from_repo: yes
+        rs_inst_set_root_pass: yes
+        rs_inst_useful_server_packages:
+            - ffmpeg
+            - mediainfo
+            - mosh
+            - tmux
+            - tree
+```           
+# rockstor-opensuse
+
+1. A typical rockstor 'Built on OpenSUSE' host should be configure following the instructions 
+here: https://forum.rockstor.com/t/built-on-opensuse-dev-notes-and-status/5662. 
+
+    *This ansible role is intended to be aligned with those install instructions.*
+
+2. After the install and initial reboot, create an SSH Key  and load it via `ssh-copy-id`. 
+Make sure you can log in using it (ie. without needing a password.)
+
+    *Note: if using vagrant this is typically already available for the vagrant user.*
+
+3. Create an inventory file for ansible, something like the following in `hosts.yml`:
+    ```yaml
+    ---
+    all:
+        hosts:
+            rockstor:
+                # Use your server's IP
+                ansible_ssh_host: 192.168.88.100
+                # Use the path to your local SSH Private Key
+                ansible_ssh_private_key_file: /home/youruser/.ssh/id_rsa_ansible
+                ansible_user: root
+    ```
+4. Create a playbook called 'main.yml'
+    ```yaml
+    ---
+    - hosts: rockstor
+      become: yes
+      become_user: root
+    
+      roles:
+        - role: rockstor_installer
+    ```
+5. Run the ansible playbook:
+    ```sh
+    ansible-playbook -i hosts.yml main.yml
+    ```

--- a/ansible/roles/rockstor_installer/defaults/main.yml
+++ b/ansible/roles/rockstor_installer/defaults/main.yml
@@ -1,0 +1,25 @@
+---
+# This option can be used to force an rockstor package install from the test repository.
+rs_inst_install_from_repo: no
+
+# An experimental option to turn on bleading edge features eg. latest BTRFS repository.
+rs_inst_experimental: no
+
+# Force the root password to a know value.
+rs_inst_set_root_pass: no # Assume the host already has one set.
+rs_inst_root_password: "{{ 'password' | password_hash('sha512', 'mysecretsalt') }}"
+
+# Rockstor currently requires IPv6 to be disabled.
+rs_inst_ipv6_disable: yes
+
+# Choose to update the OS or not.
+rs_inst_update_os: no
+
+# The user can use this to install any additional packages they may require.
+#rs_inst_useful_server_packages:
+#    - ffmpeg
+#    - mediainfo
+#    - mosh
+#    - tmux
+#    - tree
+

--- a/ansible/roles/rockstor_installer/meta/main.yml
+++ b/ansible/roles/rockstor_installer/meta/main.yml
@@ -1,0 +1,17 @@
+---
+dependencies: []
+galaxy_info:
+  role_name: rockstor_installer
+  author: mikemonkers
+  description: "OpenSUSE - This role has is a refactoring of the playbook written by Stephen Brown in his repo: https://gitlab.com/StephenBrown2/rockstor-opensuse"
+  license: GPLv3
+  min_ansible_version: 2.9
+  platforms:
+    - name: opensuse
+      versions:
+        - 15.2
+        - 16
+  galaxy_tags:
+    - rockstor
+...
+

--- a/ansible/roles/rockstor_installer/tasks/btrfs_experimental.yml
+++ b/ansible/roles/rockstor_installer/tasks/btrfs_experimental.yml
@@ -1,0 +1,20 @@
+---
+- name: Check filesystems repo file
+  stat:
+    path: /etc/zypp/repos.d/filesystems.repo
+  register: filesystems_repo
+
+- name: Add filesystems repo
+  zypper_repository:
+    repo: "{{ rs_inst_oss_repo_url }}"
+    enabled: yes
+    state: present
+    runrefresh: no
+  when: not filesystems_repo.stat.exists
+
+- name: Update btrfsprogs
+  zypper:
+    name: btrfsprogs
+    state: latest
+    refresh: yes
+    extra_args_precommand: --gpg-auto-import-keys

--- a/ansible/roles/rockstor_installer/tasks/ipv6_disable.yml
+++ b/ansible/roles/rockstor_installer/tasks/ipv6_disable.yml
@@ -1,0 +1,29 @@
+---
+- name: Check whether /etc/default/grub contains IPV6 disable already
+  command: grep "ipv6.disable=1" /etc/default/grub
+  register: check_grub_config
+  ignore_errors: yes
+  changed_when: no
+
+- name: Set GRUB_CMDLINE_LINUX
+  replace:
+    dest: /etc/default/grub
+    regexp: ^GRUB_CMDLINE_LINUX=["'](.*)["']$
+    replace: 'GRUB_CMDLINE_LINUX="ipv6.disable=1 \1"'
+    backup: yes
+  register: grub_config
+  when: check_grub_config.rc == 0
+
+- name: grub2-mkconfig
+  command: grub2-mkconfig -o /boot/grub2/grub.cfg
+  when: grub_config.changed
+
+- name: Reboot to ensure IPv6 disabled
+  reboot:
+    msg: "Reboot initiated by Ansible"
+    connect_timeout: 5
+    reboot_timeout: 300
+    pre_reboot_delay: 0
+    post_reboot_delay: 30
+    test_command: uptime
+  when: grub_config.changed

--- a/ansible/roles/rockstor_installer/tasks/main.yml
+++ b/ansible/roles/rockstor_installer/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+# TODO: We will need to add some architecture awareness here
+- debug: msg="ansible_facts.architecture={{ ansible_facts.architecture }}"
+
+- name: Set repo version (Leap)
+  set_fact:
+    rs_repo_ver: "leap/{{ ansible_facts.distribution_version }}"
+    oss_repo_ver: "Leap_{{ ansible_facts.distribution_version }}"
+    build_packages: "{{ rs_inst_build_packages + rs_inst_leap_build_packages }}"
+  when:
+    - "'Leap' in ansible_facts.distribution"
+
+- name: Set repo version (Tumbleweed)
+  set_fact:
+    rs_repo_ver: "tumbleweed"
+    oss_repo_ver: "Tumbleweed"
+    build_packages: "{{ rs_inst_build_packages + rs_inst_tumbleweed_build_packages }}"
+  when: "'Tumbleweed' in ansible_facts.distribution"
+
+- name: Verify installer options
+  include_tasks: services.yml
+
+- name: Disable IPv6 in grub
+  include_tasks: ipv6_disable.yml
+  when: rs_inst_ipv6_disable
+
+- name: Install packages
+  include_tasks: packages.yml
+
+- name: Update btrfsprogs to 5.x
+  include_tasks: btrfs_experimental.yml
+  when:
+    - rs_inst_experimental
+    - "'Leap' in ansible_facts.distribution"
+
+- name: Add ‘shells’ OBS repo
+  include_tasks: shells.yml
+
+- name: Set the Root password
+  user:
+    name: "root"
+    password: "{{ rs_inst_root_password }}"
+  when: rs_inst_set_root_pass
+
+- name: Set up Rockstor
+  include_tasks: rockstor.yml
+  when: rs_inst_install_from_repo

--- a/ansible/roles/rockstor_installer/tasks/packages.yml
+++ b/ansible/roles/rockstor_installer/tasks/packages.yml
@@ -1,0 +1,47 @@
+---
+- name: Disable non-OSS repos
+  zypper_repository:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - repo-non-oss
+    - repo-update-non-oss
+  when: ansible_facts.distribution_version != "15.1"
+
+- name: Apply all upstream updates
+  zypper:
+    name: "*"
+    state: latest
+    update_cache: yes
+    disable_recommends: yes
+  when: rs_inst_update_os
+
+- block:
+  - name: Install build packages
+    zypper:
+      name: "{{ build_packages }}"
+      state: present
+      update_cache: no
+
+  # TODO: Might help put python2 dependencies on Tumbleweed
+  - name: Install pip2 packages
+    command: pip2 install "{{ item }}"
+    loop: "{{ rs_inst_pip2_packages }}"
+
+  - name: Install pip3 packages
+    command: pip3 install "{{ item }}"
+    loop: "{{ rs_inst_pip3_packages }}"
+
+  - name: Force Postgresql 10
+    command: alternatives --set postgresql /usr/lib/postgresql10
+    when:
+      - "'Tumbleweed' in ansible_facts.distribution"
+
+  when: not rs_inst_install_from_repo
+
+- name: Install useful server admin packages
+  zypper:
+    name: "{{ rs_inst_useful_server_packages }}"
+    state: present
+    update_cache: no
+  when: rs_inst_useful_server_packages is defined

--- a/ansible/roles/rockstor_installer/tasks/rockstor.yml
+++ b/ansible/roles/rockstor_installer/tasks/rockstor.yml
@@ -1,0 +1,48 @@
+---
+- name: Import Rockstor’s public key
+  rpm_key:
+    state: present
+    key: "{{ rs_inst_update_repo_key }}"
+
+- name: Add rockstor testing channel repository
+  zypper_repository:
+    repo: "{{ rs_inst_update_repo_url }}"
+    name: "{{ rs_inst_update_repo_name }}"
+    enabled: yes
+    state: present
+    runrefresh: yes
+
+- name: Install Rockstor testing rpm
+  zypper:
+    name: rockstor
+    state: present
+    disable_recommends: yes
+
+- name: Start the relevant rockstor related systemd services
+  systemd:
+    name: rockstor
+    enabled: yes
+    daemon_reload: yes
+    state: started
+
+# TODO: Raise issue to discuss the lock down of ssh to only root
+#
+# This is needed because Rockstor locks down sshd to allow only the user 'root'.
+# Unfortunately, this breaks vagrant which relies on ssh via the user 'vagrant'. This will
+# be fairly problematic for any provisioners like ansible, salt, etc which will rely on ssh
+# access. Forcing the use of root for provisioning is probably a 'discussion' point!
+- name: Ensure vagrant can still ssh in (add vagrant to sshd AllowUsers)
+  lineinfile:
+    path: "/etc/ssh/sshd_config"
+    backrefs: yes
+    regexp: "^(.*AllowUsers.*)$"
+    line: '\1 vagrant'
+
+- name: Reboot to ensure Rockstor resiliency
+  reboot:
+    msg: "Reboot initiated by Ansible"
+    connect_timeout: 5
+    reboot_timeout: 300
+    pre_reboot_delay: 0
+    post_reboot_delay: 30
+    test_command: uptime

--- a/ansible/roles/rockstor_installer/tasks/services.yml
+++ b/ansible/roles/rockstor_installer/tasks/services.yml
@@ -1,0 +1,77 @@
+---
+- name: Populate service facts
+  service_facts:
+
+- block:
+  #- name: Ensure firewalld is disabled (Installer option)
+  # TODO: Fails on Tumbleweed
+  #  systemd:
+  #    name: firewalld
+  #    enabled: no
+  #    state: stopped
+  - name: Ensure sshd is disabled (Installer option)
+    command: systemctl disable sshd
+  - name: Ensure sshd is stopped (Installer option)
+    command: systemctl stop sshd
+  when: "'firewalld' in ansible_facts.services"
+
+- block:
+  - name: Ensure openssh is installed (Installer option)
+    zypper:
+      name: openssh
+      state: present
+      update_cache: no
+  #- name: Ensure sshd is enabled and started (Installer option)
+  # TODO: Fails on Tumbleweed
+  #  systemd:
+  #    name: sshd
+  #    enabled: yes
+  #    state: started
+  - name: Ensure sshd is enabled (Installer option)
+    command: systemctl enable sshd
+  - name: Ensure sshd is started (Installer option)
+    command: systemctl start sshd
+
+- block:
+  #- name: ensure wicked is disabled (Installer option)
+  # TODO: Fails on Tumbleweed
+  #  systemd:
+  #    name: wickedd
+  #    enabled: no
+  #    state: stopped
+  - name: Ensure wickedd is disabled (Installer option)
+    command: systemctl disable wickedd
+  - name: Ensure wickedd is stopped (Installer option)
+    command: systemctl stop wickedd
+  when: "'wickedd' in ansible_facts.services"
+
+- block:
+  - name: Ensure NetworkManager is installed (Installer option)
+    zypper:
+      name: NetworkManager
+      state: present
+      update_cache: no
+  #- name: Ensure NetworkManager is enabled (Installer option)
+  # TODO: Fails on Tumbleweed
+  #  systemd:
+  #    name: NetworkManager
+  #    enabled: yes
+  #    force: yes
+  #    state: started
+  - name: Ensure NetworkManager is enabled (Installer option)
+    command: systemctl enable -f NetworkManager
+  - name: Ensure NetworkManager is started (Installer option)
+    command: systemctl start NetworkManager
+
+- block:
+  #- name: Stop and Disable AppArmor
+  # TODO: Fails on Tumbleweed
+  #  systemd:
+  #    name: apparmor
+  #    enabled: no
+  #    state: stopped
+  - name: Ensure apparmor is disabled (Installer option)
+    command: systemctl disable apparmor
+  - name: Ensure apparmor is stopped (Installer option)
+    command: systemctl stop apparmor
+  when: "'apparmor' in ansible_facts.services"

--- a/ansible/roles/rockstor_installer/tasks/shells.yml
+++ b/ansible/roles/rockstor_installer/tasks/shells.yml
@@ -1,0 +1,19 @@
+---
+- name: Check shells repo file
+  stat:
+    path: /etc/zypp/repos.d/shells.repo
+  register: shells_repo
+
+# TODO: Fails on Tumbleweed
+- name: Add shells repo
+  zypper_repository:
+    repo: "{{ rs_inst_bs_shell_rep_url }}"
+    enabled: yes
+    priority: 105
+    state: present
+  when: not shells_repo.stat.exists
+
+- name: Refresh zypper to import shells GPG key
+  command:
+    cmd: zypper --quiet --non-interactive --gpg-auto-import-keys refresh
+    warn: no

--- a/ansible/roles/rockstor_installer/vars/main.yml
+++ b/ansible/roles/rockstor_installer/vars/main.yml
@@ -1,0 +1,42 @@
+---
+# TODO: What does Server(Tranction) mean in Rocktor dev guide.
+# TODO: We will need to add some architecture awareness here
+rs_inst_update_repo_key: "https://raw.githubusercontent.com/rockstor/rockstor-core/master/conf/ROCKSTOR-GPG-KEY"
+rs_inst_update_repo_url: "http://updates.rockstor.com:8999/rockstor-testing/{{ rs_repo_ver }}/"
+rs_inst_oss_repo_url: "https://download.opensuse.org/repositories/filesystems/openSUSE_{{ oss_repo_ver }}/filesystems.repo"
+rs_inst_bs_shell_rep_url: "https://download.opensuse.org/repositories/shells/openSUSE_{{ oss_repo_ver }}/shells.repo"
+rs_inst_update_repo_name: "Rockstor-Testing"
+rs_inst_build_packages:
+    - at
+    - dnf-plugins-core
+    - dnf-yum
+    - docker
+    - firewalld
+    - gcc
+    - gcc-c++
+    - libblkid-devel
+    - nfs-kernel-server
+    - nginx
+    - nut
+    - postgresql10
+    - postgresql10-devel
+    - postgresql10-server
+    - python-devel
+    - python-xml
+    - python2-setuptools
+    - python2-pip
+    - python3-pip
+    - samba
+
+rs_inst_leap_build_packages: []
+
+rs_inst_tumbleweed_build_packages: []
+
+rs_inst_pip2_packages:
+    - chardet
+    - distro
+    - requests
+    - six
+
+rs_inst_pip3_packages:
+    - distro

--- a/vagrant_env/Vagrantfile
+++ b/vagrant_env/Vagrantfile
@@ -1,0 +1,151 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Requires vagrant-host-shell and vagrant-vbguest
+required_plugins = %w(
+    vagrant-host-shell
+    vagrant-sshfs
+    vagrant-libvirt
+    )
+required_plugins.each do |plugin|
+  system "vagrant plugin install #{plugin}" unless Vagrant.has_plugin? plugin
+end
+system "vagrant plugin uninstall vagrant-vbguest"
+
+MEM = 2048
+CPU = 2
+SIZE_OS_HDD = "20GB"
+SIZE_DATA_HDD = "10GB"
+NUM_DATA_HDD = 2
+
+# Vagrant uses it's own build in host inventory.
+ANSIBLE_GROUPS = {
+  "all_groups:vars" => {
+        "rs_inst_set_root_pass" => "true"
+        }
+}
+
+VAGRANTFILE_API_VERSION = '2'
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+    config.vm.provider :libvirt do |lv|
+        #lv.driver = "kvm"
+        lv.driver = "qemu"
+        #lv.qemu_use_session = true
+    end
+
+    # We need to use the Rsync folder sync type because the basic VirtualBox sharing seem to get broken with a OS update
+    # Probably a kernel update breaking the vm tools.
+    config.vm.synced_folder "./", "/vagrant",
+        type: 'rsync',
+        rsync__verbose: true,
+        rsync__auto: true
+
+    # We also need to use the Rsync folder sync type for the source folder because the basic VirtualBox sharing seem
+    # to clash with the build system with regards to cross platform filesystem attributes.
+    config.vm.synced_folder "../../rockstor-core", "/opt/rockstor-core",
+        type: 'rsync',
+        rsync__exclude: [".git/", ".idea", "bin", "develop-eggs", "eggs"],
+        rsync__verbose: true,
+        rsync__auto: false
+
+    # Enforce the minimum size requirement on the OS HDD.
+    config.vm.disk :disk, size: SIZE_OS_HDD, primary: true
+
+    config.vm.define "rockstor-leap" do |rsl|
+        rsl.vm.hostname = "rockstor-leap"
+        rsl.vm.box = 'opensuse/Leap-15.2.x86_64'
+        rsl.vm.network :forwarded_port, guest: 443, host: 2443, host_ip: "0.0.0.0"
+
+        rsl.vm.provider :libvirt do |lv|
+            lv.nested = true
+            lv.memory = MEM
+            lv.cpus = CPU
+            # GUI defaults to VNC, 127.0.0.1:5900
+            lv.graphics_port = 5901
+            # Add some Data HDD to test with.
+            (1..NUM_DATA_HDD).each do |i|
+                lv.storage :file, size: SIZE_DATA_HDD, path: "data-leap-#{i}.img"
+            end
+        end
+        rsl.vm.provider :virtualbox do |vb|
+            vb.memory = MEM
+            vb.cpus = CPU
+            # To force the console to pop up. If 'false' it will run headless.
+            vb.gui = true
+        end
+        # Add some Data HDD to test with.
+        (1..NUM_DATA_HDD).each do |i|
+            rsl.vm.disk :disk, size: SIZE_DATA_HDD, name: "data-leap-#{i}"
+        end
+    end
+
+    config.vm.define "rockstor-tw" do |rstw|
+        rstw.vm.hostname = "rockstor-tw"
+        rstw.vm.box = "opensuse/Tumbleweed.x86_64"
+#         rstw.vm.network :forwarded_port, guest: 443, host: 2444, host_ip: "0.0.0.0"
+
+        rstw.vm.provider :libvirt do |lv|
+            lv.nested = true
+            lv.memory = MEM
+            lv.cpus = CPU
+            # GUI defaults to VNC, 127.0.0.1:5900
+            lv.graphics_port = 5902
+            # Add some Data HDD to test with.
+            (1..NUM_DATA_HDD).each do |i|
+                lv.storage :file, size: SIZE_DATA_HDD, path: "data-tw-#{i}.img"
+            end
+        end
+        rstw.vm.provider :virtualbox do |vb|
+            vb.memory = MEM
+            vb.cpus = CPU
+            # To force the console to pop up. If 'false' it will run headless.
+            vb.gui = true
+        end
+        # Add some Data HDD to test with.
+        (1..NUM_DATA_HDD).each do |i|
+            rstw.vm.disk :disk, size: SIZE_DATA_HDD, name: "data-tw-#{i}"
+        end
+    end
+
+#     config.vm.define "rockstor-pi" do |rspi|
+#         rspi.vm.hostname = "rockstor-pi"
+#         rspi.vm.box = 'opensuse/Leap-15.2.aarch64'
+#         #rspi.vm.box = "opensuse/Tumbleweed.aarch64"
+#         rspi.vm.network :forwarded_port, guest: 443, host: 2445, host_ip: "0.0.0.0"
+#
+#         # Only Libvirt at present (untested).
+#         rspi.vm.provider :libvirt do |lv|
+#             lv.machine_type = "raspi3" # No Pi4 yet so just switch CPU below
+#             lv.machine_arch = "aarch64"
+#             lv.cpu_mode = "custom"
+#             lv.cpu_model = "cortex-a53" # Pi3
+#             #lv.cpu_model = "cortex-a72" # Pi4
+#             lv.cpu_fallback = "allow"
+#             lv.memory = MEM
+#             lv.cpus = CPU
+#             # GUI defaults to VNC, 127.0.0.1:5900
+#             lv.graphics_port = 5903
+#             # Add some Data HDD to test with.
+#             (1..NUM_DATA_HDD).each do |i|
+#                 lv.storage :file, size: SIZE_DATA_HDD, path: "data-pi-#{i}.img"
+#             end
+#         end
+#         # Note: Aarch64 not available on VirtualBox.
+#         #
+#     end
+
+    # Inject the Aliases into the root user.
+    config.vm.provision "shell", inline: <<-SHELL
+        cat /vagrant/alias_rc >> /root/.bashrc
+    SHELL
+
+    # Provisioner using the external stand-alone ansible.
+    # (Other provisions could be added later - eg. salt, puppet...)
+    config.vm.provision "rockstor", type: "ansible" do |ansible|
+        ansible.config_file = "../ansible/ansible.cfg"
+        ansible.playbook = "../ansible/Rockstor.yml"
+        ansible.verbose = "vv"
+        ansible.groups = ANSIBLE_GROUPS
+    end
+end

--- a/vagrant_env/Vagrantfile
+++ b/vagrant_env/Vagrantfile
@@ -83,7 +83,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.define "rockstor-tw" do |rstw|
         rstw.vm.hostname = "rockstor-tw"
         rstw.vm.box = "opensuse/Tumbleweed.x86_64"
-#         rstw.vm.network :forwarded_port, guest: 443, host: 2444, host_ip: "0.0.0.0"
+        rstw.vm.network :forwarded_port, guest: 443, host: 2444, host_ip: "0.0.0.0"
 
         rstw.vm.provider :libvirt do |lv|
             lv.nested = true

--- a/vagrant_env/alias_rc
+++ b/vagrant_env/alias_rc
@@ -1,0 +1,11 @@
+
+# Some aliases used to build and test Rockstor
+REPO_DIR="/opt/rockstor-core"
+
+alias build_init="python ${REPO_DIR}/bootstrap.py -c ${REPO_DIR}/buildout.cfg"
+alias build_all="${REPO_DIR}/bin/buildout -N -c ${REPO_DIR}/buildout.cfg"
+alias build_ui="${REPO_DIR}/bin/buildout -c ${REPO_DIR}/buildout.cfg install collectstatic"
+alias make_mig_stadm="${REPO_DIR}/bin/django makemigrations storageadmin"
+alias apply_migrations_stadm="${REPO_DIR}/bin/django migrate storageadmin"
+alias make_mig_smtmgr="${REPO_DIR}/bin/django makemigrations smart_manager"
+alias apply_migrations_smtmgr="${REPO_DIR}/bin/django migrate --database=smart_manager smart_manager"

--- a/vagrant_env/build.sh
+++ b/vagrant_env/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+set -u
+#set -x
+
+export VAGRANT_EXPERIMENTAL="disks"
+
+VAGRANT_HOST="rockstor-${1:-leap}"
+VAGRANT_PROVIDER=${2:-libvirt}
+
+if ! vagrant status ${VAGRANT_HOST} | grep -q running; then
+  vagrant up ${VAGRANT_HOST} --provider ${VAGRANT_PROVIDER}
+fi
+# We are rsync'ing the build directory and it needs to be refreshed with changes.
+# (Note: this will also delete the build artifacts - effectively forcing a clean build.
+vagrant rsync ${VAGRANT_HOST}
+
+VAGRANT_PATH="/opt/rockstor-core"
+#vagrant ssh -c "ls -l ${VAGRANT_PATH}" ${VAGRANT_HOST}
+
+CODE_PATH="${VAGRANT_PATH}"
+echo "$(basename ${BASH_SOURCE[0]}): CODE_PATH is '${CODE_PATH}'"
+
+# TODO: don't run this if installed from repo RPMs - but how to know?
+vagrant ssh -c "cd ${VAGRANT_PATH}; sudo /vagrant/build_rockstor.sh" ${VAGRANT_HOST}

--- a/vagrant_env/build_rockstor.sh
+++ b/vagrant_env/build_rockstor.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+set -u
+#set -x
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+shopt -s expand_aliases
+source ${SCRIPT_DIR}/alias_rc
+
+REPO_DIR="/opt/rockstor-core/"
+
+cd "${REPO_DIR}"
+
+if [ ! -e "${PWD}"/bin/buildout ]; then
+  echo '============================================='
+  echo 'Cleaning Build'
+  echo '============================================='
+  build_init
+fi
+echo '============================================='
+echo 'Starting Build'
+echo '============================================='
+build_all
+
+if ! grep -q "vagrant" /etc/ssh/sshd_config
+then
+  echo "Re-enable 'vagrant' ssh access (removed by Rockstor install)"
+  sed -i 's/^.*\(AllowUsers root\)\(.*\)/\1 vagrant \2/' /etc/ssh/sshd_config
+fi
+echo '============================================='
+echo 'Finished Build'
+echo '============================================='


### PR DESCRIPTION
As discussed in rockstor-core issue 2206 (https://github.com/rockstor/rockstor-core/pull/2206) this initial stab at a virtualise development environment.

My test environments were:

Mac OSX High Sierra:
- Vagrant 2.2.9
- Vagrant pugs:
-- vagrant-host-shell (0.0.4, global)
-- vagrant-libvirt (0.1.2, global)
-- vagrant-sshfs (1.3.5, global)
- ansible 2.9.11
- VirtualBox 6.1.12

Mac OSX Catalina:
- Vagrant 2.2.9
-- vagrant-host-shell (0.0.4, global)
-- vagrant-libvirt (0.1.2, global)
-- vagrant-sshfs (1.3.5, global)
- ansible 2.9.11
- VirtualBox 6.1.10

OpenSUSE Leap 15.2 (VM with VM Nesting):
- Vagrant 2.2.7
-- vagrant-host-shell (0.0.4, global)
-- vagrant-libvirt (0.1.2, global)
-- vagrant-sshfs (1.3.5, global)
- ansible 2.9.6
- libvirt 6.0.0-lp152.9.3.1
- QEMU 4.2.1-lp152.9.3.1

